### PR TITLE
new patches: force_webkit, reorder_libs

### DIFF
--- a/debian/patches/force_webkit.diff
+++ b/debian/patches/force_webkit.diff
@@ -1,0 +1,29 @@
+Description: force to use webkit (ignore webengine)
+
+--- kchmviewer-7.7+20161005.2.orig/src/src.pro
++++ kchmviewer-7.7+20161005.2/src/src.pro
+@@ -114,20 +114,10 @@ unix:!macx: {
+ 
+ greaterThan(QT_MAJOR_VERSION, 4) {
+     # Qt 5
+-    greaterThan(QT_MINOR_VERSION, 5) {
+-        # Qt 5.6+
+-        error("You use Qt5.6+ - QWebEngine is not yet suitable for kchmviewer and is not supported")
+-        QT += webengine webenginewidgets
+-        DEFINES += USE_WEBENGINE
+-        SOURCES += viewwindow_webengine.cpp dataprovider_qwebengine.cpp
+-        HEADERS += dataprovider_qwebengine.h viewwindow_webengine.h
+-    } else {
+-        # Qt 5.0-5.5
+-        QT += webkit webkitwidgets
+-        DEFINES += USE_WEBKIT
+-        SOURCES += viewwindow_webkit.cpp dataprovider_qwebkit.cpp
+-        HEADERS += dataprovider_qwebkit.h viewwindow_webkit.h
+-    }
++    QT += webkit webkitwidgets
++    DEFINES += USE_WEBKIT
++    SOURCES += viewwindow_webkit.cpp dataprovider_qwebkit.cpp
++    HEADERS += dataprovider_qwebkit.h viewwindow_webkit.h
+ } else {
+     message("Qt4 is not supported anymore, please do not report any errors")
+     QT += webkit webkitwidgets

--- a/debian/patches/reorder_libs.diff
+++ b/debian/patches/reorder_libs.diff
@@ -1,0 +1,37 @@
+Description: reorder LIBS so ld can link properly
+
+--- kchmviewer-7.7+20161005.2.orig/src/src.pro
++++ kchmviewer-7.7+20161005.2/src/src.pro
+@@ -40,7 +40,7 @@ SOURCES += config.cpp \
+     textencodings.cpp \
+     treeitem_toc.cpp \
+     treeitem_index.cpp
+-LIBS += -lchm -lzip
++
+ TARGET = ../bin/kchmviewer
+ CONFIG += threads \
+     warn_on \
+@@ -67,10 +67,6 @@ QT += webkit \
+     webkitwidgets \
+     printsupport
+ 
+-linux-g++*:{
+-    LIBS += -lX11
+-}
+-
+ # This is used by cross-build on 64-bit when building a 32-bit version
+ linux-g++-32: {
+        LIBS += -L.
+@@ -112,6 +108,12 @@ unix:!macx: {
+     POST_TARGETDEPS += ../lib/libebook/libebook.a
+ }
+ 
++LIBS += -lchm -lzip
++
++linux-g++*:{
++    LIBS += -lX11
++}
++
+ greaterThan(QT_MAJOR_VERSION, 4) {
+     # Qt 5
+     QT += webkit webkitwidgets

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,4 @@
 disable_check_new_version.patch
 link-x11.diff
+force_webkit.diff
+reorder_libs.diff


### PR DESCRIPTION
 - force to use webkit (ignore webengine)
 - reorder LIBS so ld can link properly

build-depends: libqt5webkit5-dev